### PR TITLE
Stream pull requests through the cake logic as soon as they're loaded

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -19,7 +19,14 @@ type LeveledLogger interface {
 
 func New() LeveledLogger {
 	l := gklog.NewLogfmtLogger(os.Stdout)
-	kitlevels := gklevels.New(l)
+	kitlevels := gklevels.New(
+		l,
+
+		// Fudge values so that switching between debug/info levels does not
+		// mess with the log justification
+		gklevels.DebugValue("dbug"),
+		gklevels.ErrorValue("errr"),
+	)
 
 	if os.Getenv("SUPPRESS_TIMESTAMP") == "" {
 		kitlevels = kitlevels.With("ts", gklog.DefaultTimestampUTC)


### PR DESCRIPTION
Before we were bulk loading all issuse from all repos then spawning
goroutines to update each review. This wasn't optimal as review requests
that could be evaluated had to wait for later reviews to be loaded.