### PR TITLE
Validate the incoming GitHub webhook request

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ func main() {
 
 	var (
 		httpPort              = mustGetenv("PORT")
+		githubSecret          = mustGetenv("GITHUB_SECRET")
 		slackToken            = mustGetenv("SLACK_TOKEN")
 		slackUserProfileToken = mustGetenv("SLACK_USER_PROFILE_TOKEN") // FML
 	)
@@ -40,7 +41,7 @@ func main() {
 	notifier := NewSlackNotifier(slackapi.New(slackToken))
 	httpServer := http.Server{
 		Addr:    ":" + httpPort,
-		Handler: bugsnag.Handler(NewServer(notifier)),
+		Handler: bugsnag.Handler(NewServer(notifier, githubSecret)),
 	}
 
 	logger.Info("msg", fmt.Sprintf("Listening on port %s", httpPort))

--- a/main.go
+++ b/main.go
@@ -39,9 +39,10 @@ func main() {
 	}()
 
 	notifier := NewSlackNotifier(slackapi.New(slackToken))
+	webhookValidator := NewGitHubWebhookValidator(githubSecret)
 	httpServer := http.Server{
 		Addr:    ":" + httpPort,
-		Handler: bugsnag.Handler(NewServer(notifier, githubSecret)),
+		Handler: bugsnag.Handler(NewServer(notifier, webhookValidator)),
 	}
 
 	logger.Info("msg", fmt.Sprintf("Listening on port %s", httpPort))

--- a/routes_test.go
+++ b/routes_test.go
@@ -36,10 +36,19 @@ func (f *fakeNotifier) ReviewRequested(_ context.Context, webhook *github.PullRe
 	return nil
 }
 
+type fakeWebhookValidator struct {
+	secret string
+}
+
+func (f *fakeWebhookValidator) ValidateSignature(r *http.Request) error {
+	return nil
+}
+
 func TestHandleReviewRequiresChanges(t *testing.T) {
 	outcome := &fakeNotifier{}
+	validator := &fakeWebhookValidator{}
 
-	s := httptest.NewServer(NewServer(outcome))
+	s := httptest.NewServer(NewServer(outcome, validator))
 	defer s.Close()
 	webhookURL := s.URL + "/github"
 
@@ -84,8 +93,9 @@ func TestHandleReviewRequiresChanges(t *testing.T) {
 
 func TestHandleReviewApproved(t *testing.T) {
 	outcome := &fakeNotifier{}
+	validator := &fakeWebhookValidator{}
 
-	s := httptest.NewServer(NewServer(outcome))
+	s := httptest.NewServer(NewServer(outcome, validator))
 	defer s.Close()
 	webhookURL := s.URL + "/github"
 

--- a/validator.go
+++ b/validator.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+// WebhookValidator interface validates the incoming webhook request.
+type WebhookValidator interface {
+	ValidateSignature(r *http.Request) error
+}
+
+// GitHubWebhookValidator implements the validation of GitHub webhook requests
+// using a secret key.
+type GitHubWebhookValidator struct {
+	secret string
+}
+
+// NewGitHubWebhookValidator instantiates a new GitHubWebhookValidator given the
+// secret key.
+func NewGitHubWebhookValidator(secret string) *GitHubWebhookValidator {
+	return &GitHubWebhookValidator{secret}
+}
+
+// GitHubWebhookValidator implements the WebhookValidator interface.
+// The implementation uses HMAC encryption-decryption using the "secret" key.
+//
+// Refer: https://developer.github.com/webhooks/securing/#securing-your-webhooks
+func (g *GitHubWebhookValidator) ValidateSignature(r *http.Request) error {
+	signature := r.Header.Get("X-Hub-Signature")
+	if signature == "" {
+		return errors.New("No signature header provided")
+	}
+
+	// The value of the header is of the format: sha1=<actualhash>
+	gotHash := strings.SplitN(signature, "=", 2)
+	if gotHash[0] != "sha1" {
+		return errors.New("Invalid signature header provided")
+	}
+	defer r.Body.Close()
+
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+
+	hash := hmac.New(sha1.New, []byte(g.secret))
+	if _, err := hash.Write(b); err != nil {
+		return err
+	}
+
+	expectedHash := hex.EncodeToString(hash.Sum(nil))
+	if expectedHash != gotHash[1] {
+		return errors.New("Hashes do not match")
+	}
+	return nil
+}

--- a/validator.go
+++ b/validator.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/hex"
@@ -48,6 +49,9 @@ func (g *GitHubWebhookValidator) ValidateSignature(r *http.Request) error {
 	if err != nil {
 		return err
 	}
+
+	// Enable re-reading of the request body post validation
+	r.Body = ioutil.NopCloser(bytes.NewReader(b))
 
 	hash := hmac.New(sha1.New, []byte(g.secret))
 	if _, err := hash.Write(b); err != nil {


### PR DESCRIPTION
Using a custom HMAC Authenticator and a new `GITHUB_SECRET` env variable,
we can now validate that the webhook request is indeed initiated by GitHub.

**NOTE:** The `GITHUB_SECRET` is now required for running the server and must be added to the`.env` file.

Fixes #18 

Suggestions and/or feedback on improving the implementation are welcome! 😄 