### PR TITLE
Increase the max length of PR titles in notifications

### DIFF
--- a/notifier.go
+++ b/notifier.go
@@ -17,7 +17,7 @@ type Notifier interface {
 }
 
 const (
-	maxTitleLength = 35
+	maxTitleLength = 80
 	devsChannel    = "#devs"
 )
 


### PR DESCRIPTION
There's plenty of room in the notification messages for more than 35 characters, and useful information keeps getting cut off at the moment.