### PR TITLE
Fix bug with missing Slack usernames by simplifying slack/users.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,9 +29,9 @@ func main() {
 	)
 
 	slackClient := slack.New(slackToken)
-	refreshSlackUsers(slackClient)
 
 	go func() {
+		refreshSlackUsers(slackClient)
 		for range time.Tick(5 * time.Minute) {
 			refreshSlackUsers(slackClient)
 		}

--- a/notifier.go
+++ b/notifier.go
@@ -170,11 +170,7 @@ func buildUserName(ghUser *github.User) interface{} {
 }
 
 func findSlackUser(ghUser *github.User) *slackapi.User {
-	users := slack.Users.FindByGitHubUsername(ghUser.Login)
-	if len(users) > 0 {
-		return users[0]
-	}
-	return nil
+	return slack.Users.FindByGitHubUsername(ghUser.Login)
 }
 
 func prLink(url string, repo *github.Repository, pr *github.PullRequest) string {


### PR DESCRIPTION
Four main changes:

  1. Call the initial `refreshSlackUsers()` from the background goroutine at startup
  2. Fetch all users sequentially, not concurrently
  3. Only store a single Slack user per GitHub username
  4. Use `sync/atomic.Pointer` instead of a mutex

See [this Slack discussion](https://geckoboard.slack.com/archives/C02BU25TS/p1728495236400449) for details of the bug introduced by https://github.com/geckoboard/cake-bot/pull/28.